### PR TITLE
feat: php7 support (required by SF5)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.*"

--- a/src/Tbbc/RestUtil/Error/DefaultErrorFactory.php
+++ b/src/Tbbc/RestUtil/Error/DefaultErrorFactory.php
@@ -22,7 +22,7 @@ class DefaultErrorFactory implements ErrorFactoryInterface
         return '__DEFAULT__';
     }
 
-    public function createError(\Exception $exception, ExceptionMappingInterface $mapping)
+    public function createError(\Throwable $exception, ExceptionMappingInterface $mapping)
     {
         $errorMessage = $mapping->getErrorMessage();
         if (empty($errorMessage)) {

--- a/src/Tbbc/RestUtil/Error/ErrorFactoryInterface.php
+++ b/src/Tbbc/RestUtil/Error/ErrorFactoryInterface.php
@@ -27,9 +27,9 @@ interface ErrorFactoryInterface
     /**
      * Returns the Error created from the given Exception
      *
-     * @param \Exception                $exception
+     * @param \Throwable                $exception
      * @param ExceptionMappingInterface $mapping
      * @return ErrorInterface
      */
-    function createError(\Exception $exception, ExceptionMappingInterface $mapping);
+    function createError(\Throwable $exception, ExceptionMappingInterface $mapping);
 }

--- a/src/Tbbc/RestUtil/Error/ErrorResolver.php
+++ b/src/Tbbc/RestUtil/Error/ErrorResolver.php
@@ -29,7 +29,7 @@ class ErrorResolver implements ErrorResolverInterface
         $this->map = $map;
     }
 
-    public function resolve(\Exception $exception)
+    public function resolve(\Throwable $exception)
     {
         try {
             $mapping = $this->map->getMapping($exception);

--- a/src/Tbbc/RestUtil/Error/ErrorResolverInterface.php
+++ b/src/Tbbc/RestUtil/Error/ErrorResolverInterface.php
@@ -15,10 +15,10 @@ namespace Tbbc\RestUtil\Error;
 interface ErrorResolverInterface
 {
     /**
-     * Takes an \Exception and converts it into an ErrorInterface
+     * Takes an \Throwable and converts it into an ErrorInterface
      *
-     * @param \Exception $exception
+     * @param \Throwable $exception
      * @return ErrorInterface|null Returns null if no error factory supports the given exception
      */
-    function resolve(\Exception $exception);
+    function resolve(\Throwable $exception);
 }

--- a/src/Tbbc/RestUtil/Error/Mapping/ExceptionMap.php
+++ b/src/Tbbc/RestUtil/Error/Mapping/ExceptionMap.php
@@ -33,7 +33,7 @@ class ExceptionMap implements \Iterator
         }
     }
 
-    public function getMapping(\Exception $exception)
+    public function getMapping(\Throwable $exception)
     {
         foreach ($this->map as $mapping) {
             if (get_class($exception) === $mapping->getExceptionClassName()) {

--- a/tests/Tbbc/RestUtil/Tests/Error/ErrorResolverTest.php
+++ b/tests/Tbbc/RestUtil/Tests/Error/ErrorResolverTest.php
@@ -84,7 +84,7 @@ class CustomErrorFactory implements ErrorFactoryInterface
         return 'custom';
     }
 
-    public function createError(\Exception $exception, ExceptionMappingInterface $mapping)
+    public function createError(\Throwable $exception, ExceptionMappingInterface $mapping)
     {
         return new Error($mapping->getHttpStatusCode(), $mapping->getErrorCode(), $mapping->getErrorMessage(),
             $mapping->getErrorExtendedMessage(), $mapping->getErrorMoreInfoUrl());


### PR DESCRIPTION
En SF5 on gère les exceptions avec l'interface throwable (introduite en php7)